### PR TITLE
Memo based withdrawals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,6 +3127,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "orchard"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0462569fc8b0d1b158e4d640571867a4e4319225ebee2ab6647e60c70af19ae3"
+dependencies = [
+ "aes",
+ "bitvec 1.0.1",
+ "blake2b_simd",
+ "ff 0.13.0",
+ "fpe",
+ "group 0.13.0",
+ "halo2_gadgets",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "rand",
+ "reddsa",
+ "serde",
+ "subtle",
+ "tracing",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4616,10 +4646,12 @@ dependencies = [
  "futures-util",
  "hex",
  "lazy_static",
+ "orchard 0.8.0",
  "tokio",
  "tower",
  "tracing",
  "tracing-test",
+ "zcash_note_encryption",
  "zebra-chain",
  "zebra-consensus",
  "zebra-state",
@@ -4813,7 +4845,6 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "0.2.41-beta.11"
-source = "git+https://github.com/willemolding/zebra?rev=a8d1aa146fc702878ca84f63fe5c32898ffbdfcc#a8d1aa146fc702878ca84f63fe5c32898ffbdfcc"
 dependencies = [
  "futures",
  "futures-core",
@@ -4847,7 +4878,6 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.41-beta.11"
-source = "git+https://github.com/willemolding/zebra?rev=a8d1aa146fc702878ca84f63fe5c32898ffbdfcc#a8d1aa146fc702878ca84f63fe5c32898ffbdfcc"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5621,7 +5651,7 @@ dependencies = [
  "lazy_static",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.6.0",
  "rand",
  "rand_core",
  "ripemd",
@@ -5687,7 +5717,7 @@ dependencies = [
  "libc",
  "memuse",
  "metrics 0.21.1",
- "orchard",
+ "orchard 0.6.0",
  "rand",
  "rand_core",
  "rayon",
@@ -5702,9 +5732,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_spec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a3bf58b673cb3dacd8ae09ba345998923a197ab0da70d6239d8e8838949e9b"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
 name = "zebra-chain"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=a8d1aa146fc702878ca84f63fe5c32898ffbdfcc#a8d1aa146fc702878ca84f63fe5c32898ffbdfcc"
 dependencies = [
  "bitflags 2.5.0",
  "bitflags-serde-legacy",
@@ -5728,7 +5766,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard",
+ "orchard 0.6.0",
  "primitive-types 0.11.1",
  "proptest",
  "proptest-derive",
@@ -5762,7 +5800,6 @@ dependencies = [
 [[package]]
 name = "zebra-consensus"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=a8d1aa146fc702878ca84f63fe5c32898ffbdfcc#a8d1aa146fc702878ca84f63fe5c32898ffbdfcc"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5776,7 +5813,7 @@ dependencies = [
  "lazy_static",
  "metrics 0.22.3",
  "once_cell",
- "orchard",
+ "orchard 0.6.0",
  "rand",
  "rayon",
  "serde",
@@ -5798,7 +5835,6 @@ dependencies = [
 [[package]]
 name = "zebra-node-services"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=a8d1aa146fc702878ca84f63fe5c32898ffbdfcc#a8d1aa146fc702878ca84f63fe5c32898ffbdfcc"
 dependencies = [
  "zebra-chain",
 ]
@@ -5806,7 +5842,6 @@ dependencies = [
 [[package]]
 name = "zebra-script"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=a8d1aa146fc702878ca84f63fe5c32898ffbdfcc#a8d1aa146fc702878ca84f63fe5c32898ffbdfcc"
 dependencies = [
  "displaydoc",
  "thiserror",
@@ -5817,7 +5852,6 @@ dependencies = [
 [[package]]
 name = "zebra-state"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=a8d1aa146fc702878ca84f63fe5c32898ffbdfcc#a8d1aa146fc702878ca84f63fe5c32898ffbdfcc"
 dependencies = [
  "bincode",
  "chrono",
@@ -5851,7 +5885,6 @@ dependencies = [
 [[package]]
 name = "zebra-test"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=a8d1aa146fc702878ca84f63fe5c32898ffbdfcc#a8d1aa146fc702878ca84f63fe5c32898ffbdfcc"
 dependencies = [
  "color-eyre",
  "futures",
@@ -5914,4 +5947,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.53",
+]
+
+[[package]]
+name = "zip32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4226d0aee9c9407c27064dfeec9d7b281c917de3374e1e5a2e2cfad9e09de19e"
+dependencies = [
+ "blake2b_simd",
+ "memuse",
+ "subtle",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-json-abi",
  "anyhow",
+ "base58check",
  "base64-url",
  "cartezcash-lightwalletd",
  "chrono",
@@ -816,6 +817,9 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uint",
+ "zcash_address",
+ "zcash_keys",
+ "zcash_primitives 0.15.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-state",
@@ -2531,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361c467824d4d9d4f284be4b2608800839419dccc4d4608f28345237fe354623"
+checksum = "eb1872810fb725b06b8c153dde9e86f3ec26747b9b60096da7a869883b549cbe"
 dependencies = [
  "either",
 ]
@@ -4066,6 +4070,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sapling-crypto"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f4270033afcb0c74c5c7d59c73cfd1040367f67f224fe7ed9a919ae618f1b7"
+dependencies = [
+ "aes",
+ "bellman",
+ "bitvec 1.0.1",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bls12_381",
+ "byteorder",
+ "document-features",
+ "ff 0.13.0",
+ "fpe",
+ "group 0.13.0",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "lazy_static",
+ "memuse",
+ "rand",
+ "rand_core",
+ "redjubjub",
+ "subtle",
+ "tracing",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,6 +4198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -4642,6 +4687,7 @@ dependencies = [
 name = "tiny-cash"
 version = "0.1.0"
 dependencies = [
+ "base58check",
  "chrono",
  "futures-util",
  "hex",
@@ -5615,6 +5661,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_keys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663489ffb4e51bc4436ff8796832612a9ff3c6516f1c620b5a840cb5dcd7b866"
+dependencies = [
+ "bech32 0.9.1",
+ "blake2b_simd",
+ "bls12_381",
+ "bs58 0.5.1",
+ "document-features",
+ "group 0.13.0",
+ "memuse",
+ "nonempty",
+ "orchard 0.8.0",
+ "rand_core",
+ "secrecy",
+ "subtle",
+ "tracing",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_primitives 0.15.0",
+ "zcash_protocol",
+ "zip32",
+]
+
+[[package]]
 name = "zcash_note_encryption"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5664,6 +5736,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_primitives"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a8d812efec385ecbcefc862c0005bb1336474ea7dd9b671d5bbddaadd04be2"
+dependencies = [
+ "aes",
+ "bip0039",
+ "blake2b_simd",
+ "byteorder",
+ "document-features",
+ "equihash",
+ "ff 0.13.0",
+ "fpe",
+ "group 0.13.0",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard 0.8.0",
+ "rand",
+ "rand_core",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2 0.10.8",
+ "subtle",
+ "tracing",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
 name = "zcash_proofs"
 version = "0.13.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5681,7 +5789,7 @@ dependencies = [
  "redjubjub",
  "tracing",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.13.0-rc.1",
 ]
 
 [[package]]
@@ -5727,7 +5835,7 @@ dependencies = [
  "zcash_address",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.13.0-rc.1",
  "zcash_proofs",
 ]
 
@@ -5793,7 +5901,7 @@ dependencies = [
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.13.0-rc.1",
  "zebra-test",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ zebra-consensus = { workspace = true }
 tiny-cash = { path = "tiny-cash" }
 cartezcash-lightwalletd = { path = "cartezcash-lightwalletd" }
 tower-cartesi = { path = "tower-cartesi" }
+base58check = "0.1.0"
+zcash_address = "0.3.2"
+zcash_keys = { version = "0.2.0", features = ["orchard"] }
+zcash_primitives = "0.15.0"
 
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,16 @@ members = [ "cartezcash-lightwalletd", "tiny-cash", "tower-cartesi"]
 [workspace.dependencies]
 
 # patched zebra crates to support TinyCash network and expose things we need
-zebra-consensus = { git = "https://github.com/willemolding/zebra", rev = "a8d1aa146fc702878ca84f63fe5c32898ffbdfcc", default-features = false }
-zebra-state = { git = "https://github.com/willemolding/zebra", rev = "a8d1aa146fc702878ca84f63fe5c32898ffbdfcc", default-features = false }
-zebra-test = { git = "https://github.com/willemolding/zebra", rev = "a8d1aa146fc702878ca84f63fe5c32898ffbdfcc", default-features = false }
-zebra-chain = { git = "https://github.com/willemolding/zebra", rev = "a8d1aa146fc702878ca84f63fe5c32898ffbdfcc", default-features = false }
+# zebra-consensus = { git = "https://github.com/willemolding/zebra", rev = "a8d1aa146fc702878ca84f63fe5c32898ffbdfcc", default-features = false }
+# zebra-state = { git = "https://github.com/willemolding/zebra", rev = "a8d1aa146fc702878ca84f63fe5c32898ffbdfcc", default-features = false }
+# zebra-test = { git = "https://github.com/willemolding/zebra", rev = "a8d1aa146fc702878ca84f63fe5c32898ffbdfcc", default-features = false }
+# zebra-chain = { git = "https://github.com/willemolding/zebra", rev = "a8d1aa146fc702878ca84f63fe5c32898ffbdfcc", default-features = false }
+
+zebra-consensus = { path = "../zebra/zebra-consensus", default-features = false }
+zebra-state = { path = "../zebra/zebra-state", default-features = false }
+zebra-test = { path = "../zebra/zebra-test", default-features = false }
+zebra-chain = { path = "../zebra/zebra-chain", default-features = false }
+
 
 [patch.crates-io]
 # Ring needed to be patched as while the current version supports riscv, the version used by Zebra doesn't.

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let network = Network::Mainnet;
 
-    println!("Withdraw address is: {}", tiny_cash::mt_doom());
+    println!("Withdraw address is: {:?}", tiny_cash::mt_doom_address());
 
     // TODO: Enable this when not debugging
     // tracing::info!("Initializing Halo2 verifier key");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,9 @@ use cartezcash_lightwalletd::{
     service_impl::CompactTxStreamerImpl,
 };
 use service::{CarteZcashService, Request};
+use zcash_keys::address::UnifiedAddress;
+use zcash_primitives::consensus::MAIN_NETWORK;
+
 use std::env;
 use std::error::Error;
 use std::future::Future;
@@ -41,7 +44,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let network = Network::Mainnet;
 
-    println!("Withdraw address is: {:?}", tiny_cash::mt_doom_address());
+    println!("Withdraw address is: {}", UnifiedAddress::from_receivers(Some(tiny_cash::mt_doom_address()), None).unwrap().encode(&MAIN_NETWORK));
 
     // TODO: Enable this when not debugging
     // tracing::info!("Initializing Halo2 verifier key");

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -65,7 +65,10 @@ where
                             to: to.create_script_from_address(),
                         })
                         .await
-                        .map(|res| res.burned.into())
+                        .map(|res| {
+                            tracing::info!("detected burns: {:?}", res.burns);
+                            0
+                        })
                 }
                 Request::Transact { txn, .. } => {
                     tracing::debug!("handling transact request for txn {:?}", txn);
@@ -74,7 +77,10 @@ where
                         .await?
                         .call(tiny_cash::write::Request::IncludeTransaction { transaction: txn })
                         .await
-                        .map(|res| res.burned.into())
+                        .map(|res| {
+                            tracing::info!("detected burns: {:?}", res.burns);
+                            0
+                        })
                 }
             }
         }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,46 +1,53 @@
 use futures_util::future::FutureExt;
 use std::future::Future;
 use std::pin::Pin;
-use tower::{Service, ServiceExt};
+use tower::{BoxError, Service, ServiceExt};
+use zebra_chain::amount::{Amount, NonNegative};
 
 pub use request::Request;
 
 mod request;
-pub struct CarteZcashService<S, SR> {
+pub struct CarteZcashService<S> {
     tiny_cash: S,
-    state_read_service: SR,
 }
 
-impl<S, SR> CarteZcashService<S, SR> {
-    pub fn new(tiny_cash: S, state_read_service: SR) -> Self {
+pub struct Response {
+    pub withdrawals: Vec<(ethereum_types::Address, ethereum_types::U256)>,
+}
+
+impl<S> CarteZcashService<S> {
+    pub fn new(tiny_cash: S) -> Self {
+        Self { tiny_cash }
+    }
+}
+
+impl From<tiny_cash::write::Response> for Response {
+    fn from(res: tiny_cash::write::Response) -> Self {
         Self {
-            tiny_cash,
-            state_read_service,
+            withdrawals: res
+                .burns
+                .iter()
+                .map(|(amount, memo)| {
+                    (
+                        ethereum_types::Address::from_slice(&memo.0[..20]),
+                        ethereum_types::U256::from(amount.zatoshis()),
+                    )
+                })
+                .collect(),
         }
     }
 }
 
-impl<S, SR> Service<Request> for CarteZcashService<S, SR>
+impl<S> Service<Request> for CarteZcashService<S>
 where
-    S: Service<
-            tiny_cash::write::Request,
-            Response = tiny_cash::write::Response,
-            Error = tiny_cash::write::BoxError,
-        > + Send
+    S: Service<tiny_cash::write::Request, Response = tiny_cash::write::Response, Error = BoxError>
+        + Send
         + Clone
         + 'static,
     S::Future: Send + 'static,
-    SR: Service<
-            zebra_state::ReadRequest,
-            Response = zebra_state::ReadResponse,
-            Error = zebra_state::BoxError,
-        > + Send
-        + Clone
-        + 'static,
-    SR::Future: Send + 'static,
 {
-    type Response = u64;
-    type Error = tiny_cash::write::BoxError;
+    type Response = Response;
+    type Error = BoxError;
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
@@ -67,7 +74,7 @@ where
                         .await
                         .map(|res| {
                             tracing::info!("detected burns: {:?}", res.burns);
-                            0
+                            res.into()
                         })
                 }
                 Request::Transact { txn, .. } => {
@@ -79,7 +86,7 @@ where
                         .await
                         .map(|res| {
                             tracing::info!("detected burns: {:?}", res.burns);
-                            0
+                            res.into()
                         })
                 }
             }

--- a/src/service/request.rs
+++ b/src/service/request.rs
@@ -15,7 +15,6 @@ pub enum Request {
         to: Address,
     },
     Transact {
-        withdraw_address: ethereum_types::Address,
         txn: Transaction,
     },
 }
@@ -67,18 +66,14 @@ impl TryFrom<(tower_cartesi::AdvanceStateMetadata, Vec<u8>)> for Request {
                     transaction bytes // arbitrary size
                  */
 
-                let withdraw_address = ethereum_types::Address::zero();
-
                 let txn = zebra_chain::transaction::Transaction::zcash_deserialize(payload.as_slice())?;
 
                 tracing::info!(
-                    "Received transaction request {} send burns to {}",
-                    txn.hash(),
-                    withdraw_address
+                    "Received transaction request {}",
+                    txn.hash()
                 );
 
                 Ok(Request::Transact {
-                    withdraw_address,
                     txn,
                 })
             }
@@ -94,14 +89,12 @@ impl std::fmt::Debug for Request {
                 write!(f, "Deposit {} to {}", amount, to)
             }
             Request::Transact {
-                withdraw_address,
                 txn,
             } => {
                 write!(
                     f,
-                    "Transact hash {} with withdrawal address {}",
+                    "Transact hash {}",
                     txn.hash(),
-                    withdraw_address
                 )
             }
         }

--- a/tiny-cash/Cargo.toml
+++ b/tiny-cash/Cargo.toml
@@ -17,6 +17,8 @@ zebra-state = { workspace = true, default-features = false, features = ["proptes
 zebra-test = { workspace = true, default-features = false }
 zebra-chain = { workspace = true, default-features = false, features = ["proptest-impl"] }
 lazy_static = "1.4.0"
+orchard = "0.8.0"
+zcash_note_encryption = "0.4.0"
 
 
 [dev-dependencies]

--- a/tiny-cash/Cargo.toml
+++ b/tiny-cash/Cargo.toml
@@ -19,6 +19,7 @@ zebra-chain = { workspace = true, default-features = false, features = ["proptes
 lazy_static = "1.4.0"
 orchard = "0.8.0"
 zcash_note_encryption = "0.4.0"
+base58check = "0.1.0"
 
 
 [dev-dependencies]

--- a/tiny-cash/src/lib.rs
+++ b/tiny-cash/src/lib.rs
@@ -1,13 +1,61 @@
-use zebra_chain::{parameters::Network, transparent};
+use orchard::{
+    keys::{FullViewingKey, IncomingViewingKey, PreparedIncomingViewingKey, Scope},
+    note::{ExtractedNoteCommitment, Nullifier},
+    note_encryption::OrchardDomain,
+};
+use zcash_note_encryption::{
+    try_note_decryption, EphemeralKeyBytes, ShieldedOutput, ENC_CIPHERTEXT_SIZE,
+};
+use zebra_chain::{
+    amount::{Amount, NonNegative},
+    orchard::Action,
+    transaction::Memo,
+};
 
 #[cfg(test)]
 mod test;
 pub mod write;
 
-// outputs locked with this script are considered burned and can be released on L1
-// this script pushed false to the stack so funds can never be spent
-pub fn mt_doom() -> transparent::Address {
-    transparent::Address::from_pub_key_hash(Network::Mainnet, [0; 20])
+// outputs send to this address cannot be recovered and are considered burned
+pub fn mt_doom_address() -> orchard::Address {
+    FullViewingKey::from_bytes(&[0_u8; 96])
+        .unwrap()
+        .address_at(0_usize, Scope::External)
+}
+
+pub fn mt_doom_ivk() -> IncomingViewingKey {
+    FullViewingKey::from_bytes(&[0_u8; 96])
+        .unwrap()
+        .to_ivk(Scope::External)
+}
+
+// Attempt to decrypt action. It it was encrypted to Mt Doom address, return the amount and memo
+pub fn extract_burn_info(action: &Action) -> Option<(Amount<NonNegative>, Memo)> {
+    try_note_decryption(
+        &OrchardDomain::for_compact_action(&dummy_action()),
+        &PreparedIncomingViewingKey::new(&mt_doom_ivk()),
+        &DecryptableAction(action.clone()),
+    )
+    .map(|(note, _, memo)| {
+        let memo = memo[..].try_into().unwrap();
+        (Amount::try_from(note.value().inner()).unwrap(), memo)
+    })
+}
+
+struct DecryptableAction(Action);
+
+impl ShieldedOutput<OrchardDomain, ENC_CIPHERTEXT_SIZE> for DecryptableAction {
+    fn ephemeral_key(&self) -> EphemeralKeyBytes {
+        EphemeralKeyBytes(self.0.ephemeral_key.into())
+    }
+
+    fn cmstar_bytes(&self) -> [u8; 32] {
+        self.0.cm_x.into()
+    }
+
+    fn enc_ciphertext(&self) -> &[u8; ENC_CIPHERTEXT_SIZE] {
+        &self.0.enc_ciphertext.0
+    }
 }
 
 /// force initialization of the Orchard verifying key.
@@ -16,4 +64,13 @@ pub fn mt_doom() -> transparent::Address {
 /// it will be initialized the first time a shielded transaction is verified
 pub fn initialize_halo2() {
     lazy_static::initialize(&zebra_consensus::halo2::VERIFYING_KEY);
+}
+
+fn dummy_action() -> orchard::note_encryption::CompactAction {
+    orchard::note_encryption::CompactAction::from_parts(
+        Nullifier::from_bytes(&[0_u8; 32]).unwrap(),
+        ExtractedNoteCommitment::from_bytes(&[0_u8; 32]).unwrap(),
+        EphemeralKeyBytes([0_u8; 32]),
+        [0_u8; 52],
+    )
 }


### PR DESCRIPTION
Closes #9 

Use the encrypted note memo field to provide the withdrawal address. This requires switching Mt Doom to be a shielded address rather than a transparent one and doing a trial-decryption of every spent note to check for withdrawals.