### PR TITLE
Store state in TinyCash rather than rely on Zebra State Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4263,6 +4263,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "hex",
+ "incrementalmerkletree",
  "lazy_static",
  "orchard 0.8.0",
  "tokio",
@@ -4464,6 +4465,7 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "0.2.41-beta.11"
+source = "git+https://github.com/willemolding/zebra?rev=04615946f3bae4e39925edae8ed1e150b7cf531a#04615946f3bae4e39925edae8ed1e150b7cf531a"
 dependencies = [
  "futures",
  "futures-core",
@@ -4497,6 +4499,7 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.41-beta.11"
+source = "git+https://github.com/willemolding/zebra?rev=04615946f3bae4e39925edae8ed1e150b7cf531a#04615946f3bae4e39925edae8ed1e150b7cf531a"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5409,6 +5412,7 @@ dependencies = [
 [[package]]
 name = "zebra-chain"
 version = "1.0.0-beta.35"
+source = "git+https://github.com/willemolding/zebra?rev=04615946f3bae4e39925edae8ed1e150b7cf531a#04615946f3bae4e39925edae8ed1e150b7cf531a"
 dependencies = [
  "bitflags 2.5.0",
  "bitflags-serde-legacy",
@@ -5466,6 +5470,7 @@ dependencies = [
 [[package]]
 name = "zebra-consensus"
 version = "1.0.0-beta.35"
+source = "git+https://github.com/willemolding/zebra?rev=04615946f3bae4e39925edae8ed1e150b7cf531a#04615946f3bae4e39925edae8ed1e150b7cf531a"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5501,6 +5506,7 @@ dependencies = [
 [[package]]
 name = "zebra-node-services"
 version = "1.0.0-beta.35"
+source = "git+https://github.com/willemolding/zebra?rev=04615946f3bae4e39925edae8ed1e150b7cf531a#04615946f3bae4e39925edae8ed1e150b7cf531a"
 dependencies = [
  "zebra-chain",
 ]
@@ -5508,6 +5514,7 @@ dependencies = [
 [[package]]
 name = "zebra-script"
 version = "1.0.0-beta.35"
+source = "git+https://github.com/willemolding/zebra?rev=04615946f3bae4e39925edae8ed1e150b7cf531a#04615946f3bae4e39925edae8ed1e150b7cf531a"
 dependencies = [
  "displaydoc",
  "thiserror",
@@ -5518,6 +5525,7 @@ dependencies = [
 [[package]]
 name = "zebra-state"
 version = "1.0.0-beta.35"
+source = "git+https://github.com/willemolding/zebra?rev=04615946f3bae4e39925edae8ed1e150b7cf531a#04615946f3bae4e39925edae8ed1e150b7cf531a"
 dependencies = [
  "bincode",
  "chrono",
@@ -5551,6 +5559,7 @@ dependencies = [
 [[package]]
 name = "zebra-test"
 version = "1.0.0-beta.35"
+source = "git+https://github.com/willemolding/zebra?rev=04615946f3bae4e39925edae8ed1e150b7cf531a#04615946f3bae4e39925edae8ed1e150b7cf531a"
 dependencies = [
  "color-eyre",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,59 +76,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
-name = "alloy-json-abi"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ed0f2a6c3a1c947b4508522a53a190dba8f94dcd4e3e1a5af945a498e78f2f"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-type-parser",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d34d8de81e23b6d909c094e23b3d357e01ca36b78a8c5424c501eedbe86f0"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more",
- "hex-literal",
- "itoa",
- "k256 0.13.3",
- "keccak-asm",
- "proptest",
- "rand",
- "ruint",
- "serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-rlp"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
-dependencies = [
- "arrayvec",
- "bytes",
-]
-
-[[package]]
-name = "alloy-sol-type-parser"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0045cc89524e1451ccf33e8581355b6027ac7c6e494bb02959d4213ad0d8e91d"
-dependencies = [
- "winnow 0.6.5",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,130 +95,6 @@ name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
-
-[[package]]
-name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version 0.4.0",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint",
- "num-traits",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
-dependencies = [
- "ark-std 0.3.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits",
- "rand",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand",
-]
 
 [[package]]
 name = "arrayref"
@@ -326,7 +149,7 @@ checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
  "futures",
  "pharos",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -423,12 +246,6 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base58"
@@ -786,7 +603,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.22",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",
@@ -796,14 +613,10 @@ dependencies = [
 name = "cartezcash"
 version = "0.1.0"
 dependencies = [
- "alloy-json-abi",
  "anyhow",
  "base58check",
- "base64-url",
  "cartezcash-lightwalletd",
  "chrono",
- "ciborium",
- "ethabi",
  "ethereum-types",
  "futures-util",
  "hex",
@@ -993,7 +806,7 @@ dependencies = [
  "digest 0.10.7",
  "getrandom",
  "hmac",
- "k256 0.11.6",
+ "k256",
  "lazy_static",
  "serde",
  "sha2 0.10.8",
@@ -1078,19 +891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-hex"
-version = "1.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba00838774b4ab0233e355d26710fbfc8327a05c017f6dc4873f876d1f79f78"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "hex",
- "proptest",
- "serde",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,12 +901,6 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -1195,18 +989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array 0.14.7",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,7 +1019,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "platforms",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "subtle",
  "zeroize",
@@ -1361,26 +1143,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 
@@ -1395,21 +1164,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1468,23 +1227,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
+ "elliptic-curve",
+ "rfc6979",
  "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der 0.7.8",
- "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
 ]
 
 [[package]]
@@ -1526,8 +1271,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
+ "base16ct",
+ "crypto-bigint",
  "der 0.6.1",
  "digest 0.10.7",
  "ff 0.12.1",
@@ -1535,26 +1280,7 @@ dependencies = [
  "group 0.12.1",
  "pkcs8 0.9.0",
  "rand_core",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
- "digest 0.10.7",
- "ff 0.13.0",
- "generic-array 0.14.7",
- "group 0.13.0",
- "pkcs8 0.10.2",
- "rand_core",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1766,12 +1492,12 @@ dependencies = [
  "bytes",
  "cargo_metadata",
  "chrono",
- "convert_case 0.6.0",
- "elliptic-curve 0.12.3",
+ "convert_case",
+ "elliptic-curve",
  "ethabi",
  "generic-array 0.14.7",
  "hex",
- "k256 0.11.6",
+ "k256",
  "once_cell",
  "open-fastrlp",
  "proc-macro2",
@@ -1796,7 +1522,7 @@ dependencies = [
  "ethers-core",
  "getrandom",
  "reqwest",
- "semver 1.0.22",
+ "semver",
  "serde",
  "serde-aux",
  "serde_json",
@@ -1874,7 +1600,7 @@ dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
- "elliptic-curve 0.12.3",
+ "elliptic-curve",
  "eth-keystore",
  "ethers-core",
  "hex",
@@ -1913,17 +1639,6 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
-
-[[package]]
-name = "fastrlp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
-dependencies = [
- "arrayvec",
- "auto_impl 1.2.0",
- "bytes",
-]
 
 [[package]]
 name = "ff"
@@ -2142,7 +1857,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -2612,15 +2326,6 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -2688,24 +2393,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
+ "ecdsa",
+ "elliptic-curve",
  "sha2 0.10.8",
  "sha3",
-]
-
-[[package]]
-name = "k256"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
-dependencies = [
- "cfg-if",
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "once_cell",
- "sha2 0.10.8",
- "signature 2.2.0",
 ]
 
 [[package]]
@@ -2715,16 +2406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
-]
-
-[[package]]
-name = "keccak-asm"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb8515fff80ed850aea4a1595f2e519c003e2a00a82fe168ebf5269196caf444"
-dependencies = [
- "digest 0.10.7",
- "sha3-asm",
 ]
 
 [[package]]
@@ -3299,12 +2980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
 name = "pbkdf2"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,24 +3008,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pest"
-version = "2.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -3825,19 +3489,9 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint 0.4.9",
+ "crypto-bigint",
  "hmac",
  "zeroize",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
 ]
 
 [[package]]
@@ -3918,36 +3572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruint"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f308135fef9fc398342da5472ce7c484529df23743fb7c734e0f3d472971e62"
-dependencies = [
- "alloy-rlp",
- "ark-ff 0.3.0",
- "ark-ff 0.4.2",
- "bytes",
- "fastrlp",
- "num-bigint",
- "num-traits",
- "parity-scale-codec",
- "primitive-types 0.12.2",
- "proptest",
- "rand",
- "rlp",
- "ruint-macro",
- "serde",
- "valuable",
- "zeroize",
-]
-
-[[package]]
-name = "ruint-macro"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86854cf50259291520509879a5c294c3c9a4c334e9ff65071c51e42ef1e2343"
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3967,20 +3591,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.22",
+ "semver",
 ]
 
 [[package]]
@@ -4159,24 +3774,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct 0.1.1",
+ "base16ct",
  "der 0.6.1",
  "generic-array 0.14.7",
  "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct 0.2.0",
- "der 0.7.8",
- "generic-array 0.14.7",
- "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -4211,29 +3812,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -4368,16 +3951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3-asm"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac61da6b35ad76b195eb4771210f947734321a8d81d7738e1580d953bc7a15e"
-dependencies = [
- "cc",
- "cfg-if",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4417,7 +3990,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core",
 ]
 
@@ -4827,7 +4399,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.5",
  "toml_datetime",
- "winnow 0.5.40",
+ "winnow",
 ]
 
 [[package]]
@@ -4838,7 +4410,7 @@ checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.2.5",
  "toml_datetime",
- "winnow 0.5.40",
+ "winnow",
 ]
 
 [[package]]
@@ -5061,12 +4633,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "uint"
@@ -5555,15 +5121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winnow"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5584,7 +5141,7 @@ dependencies = [
  "js-sys",
  "log",
  "pharos",
- "rustc_version 0.4.0",
+ "rustc_version",
  "send_wrapper",
  "thiserror",
  "wasm-bindgen",
@@ -5986,7 +5543,7 @@ dependencies = [
  "regex",
  "rlimit",
  "rocksdb",
- "semver 1.0.22",
+ "semver",
  "serde",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4272,6 +4272,7 @@ dependencies = [
  "zcash_note_encryption",
  "zebra-chain",
  "zebra-consensus",
+ "zebra-script",
  "zebra-state",
  "zebra-test",
 ]
@@ -4463,7 +4464,6 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "0.2.41-beta.11"
-source = "git+https://github.com/willemolding/zebra?rev=185e404bed938e3aa916aee1ae6999a70efceddb#185e404bed938e3aa916aee1ae6999a70efceddb"
 dependencies = [
  "futures",
  "futures-core",
@@ -4497,7 +4497,6 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.41-beta.11"
-source = "git+https://github.com/willemolding/zebra?rev=185e404bed938e3aa916aee1ae6999a70efceddb#185e404bed938e3aa916aee1ae6999a70efceddb"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5410,7 +5409,6 @@ dependencies = [
 [[package]]
 name = "zebra-chain"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=185e404bed938e3aa916aee1ae6999a70efceddb#185e404bed938e3aa916aee1ae6999a70efceddb"
 dependencies = [
  "bitflags 2.5.0",
  "bitflags-serde-legacy",
@@ -5468,7 +5466,6 @@ dependencies = [
 [[package]]
 name = "zebra-consensus"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=185e404bed938e3aa916aee1ae6999a70efceddb#185e404bed938e3aa916aee1ae6999a70efceddb"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5504,7 +5501,6 @@ dependencies = [
 [[package]]
 name = "zebra-node-services"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=185e404bed938e3aa916aee1ae6999a70efceddb#185e404bed938e3aa916aee1ae6999a70efceddb"
 dependencies = [
  "zebra-chain",
 ]
@@ -5512,7 +5508,6 @@ dependencies = [
 [[package]]
 name = "zebra-script"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=185e404bed938e3aa916aee1ae6999a70efceddb#185e404bed938e3aa916aee1ae6999a70efceddb"
 dependencies = [
  "displaydoc",
  "thiserror",
@@ -5523,7 +5518,6 @@ dependencies = [
 [[package]]
 name = "zebra-state"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=185e404bed938e3aa916aee1ae6999a70efceddb#185e404bed938e3aa916aee1ae6999a70efceddb"
 dependencies = [
  "bincode",
  "chrono",
@@ -5557,7 +5551,6 @@ dependencies = [
 [[package]]
 name = "zebra-test"
 version = "1.0.0-beta.35"
-source = "git+https://github.com/willemolding/zebra?rev=185e404bed938e3aa916aee1ae6999a70efceddb#185e404bed938e3aa916aee1ae6999a70efceddb"
 dependencies = [
  "color-eyre",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,24 +24,23 @@ ethereum-types = "0.14.1"
 futures-util = "0.3.30"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-ethabi = "18.0.0"
-ciborium = "0.2.2"
-base64-url = "2.0.2"
-alloy-json-abi = "0.6.4"
-tonic = "0.11"
+tonic = { version = "0.11", optional = true}
 
 zebra-chain = { workspace = true }
 zebra-state = { workspace = true }
 zebra-consensus = { workspace = true }
 
 tiny-cash = { path = "tiny-cash" }
-cartezcash-lightwalletd = { path = "cartezcash-lightwalletd" }
+cartezcash-lightwalletd = { path = "cartezcash-lightwalletd", optional = true}
 tower-cartesi = { path = "tower-cartesi" }
 base58check = "0.1.0"
 zcash_address = "0.3.2"
 zcash_keys = { version = "0.2.0", features = ["orchard"] }
 zcash_primitives = "0.15.0"
 
+[features]
+default = []
+lightwalletd = ["dep:cartezcash-lightwalletd", "dep:tonic"]
 
 [workspace]
 members = [ "cartezcash-lightwalletd", "tiny-cash", "tower-cartesi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,18 +48,18 @@ members = [ "cartezcash-lightwalletd", "tiny-cash", "tower-cartesi"]
 [workspace.dependencies]
 
 # patched zebra crates to support TinyCash network and expose things we need
-# zebra-consensus = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
-# zebra-state = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
-# zebra-test = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
-# zebra-chain = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
-# zebra-script = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
+zebra-consensus = { git = "https://github.com/willemolding/zebra", rev = "04615946f3bae4e39925edae8ed1e150b7cf531a", default-features = false }
+zebra-state = { git = "https://github.com/willemolding/zebra", rev = "04615946f3bae4e39925edae8ed1e150b7cf531a", default-features = false }
+zebra-test = { git = "https://github.com/willemolding/zebra", rev = "04615946f3bae4e39925edae8ed1e150b7cf531a", default-features = false }
+zebra-chain = { git = "https://github.com/willemolding/zebra", rev = "04615946f3bae4e39925edae8ed1e150b7cf531a", default-features = false }
+zebra-script = { git = "https://github.com/willemolding/zebra", rev = "04615946f3bae4e39925edae8ed1e150b7cf531a", default-features = false }
 
 # uncomment for local dev when modifying zebra
-zebra-consensus = { path = "../zebra/zebra-consensus", default-features = false }
-zebra-state = { path = "../zebra/zebra-state", default-features = false }
-zebra-test = { path = "../zebra/zebra-test", default-features = false }
-zebra-chain = { path = "../zebra/zebra-chain", default-features = false }
-zebra-script = { path = "../zebra/zebra-script", default-features = false }
+# zebra-consensus = { path = "../zebra/zebra-consensus", default-features = false }
+# zebra-state = { path = "../zebra/zebra-state", default-features = false }
+# zebra-test = { path = "../zebra/zebra-test", default-features = false }
+# zebra-chain = { path = "../zebra/zebra-chain", default-features = false }
+# zebra-script = { path = "../zebra/zebra-script", default-features = false }
 
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,16 +48,18 @@ members = [ "cartezcash-lightwalletd", "tiny-cash", "tower-cartesi"]
 [workspace.dependencies]
 
 # patched zebra crates to support TinyCash network and expose things we need
-zebra-consensus = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
-zebra-state = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
-zebra-test = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
-zebra-chain = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
+# zebra-consensus = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
+# zebra-state = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
+# zebra-test = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
+# zebra-chain = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
+# zebra-script = { git = "https://github.com/willemolding/zebra", rev = "185e404bed938e3aa916aee1ae6999a70efceddb", default-features = false }
 
 # uncomment for local dev when modifying zebra
-# zebra-consensus = { path = "../zebra/zebra-consensus", default-features = false }
-# zebra-state = { path = "../zebra/zebra-state", default-features = false }
-# zebra-test = { path = "../zebra/zebra-test", default-features = false }
-# zebra-chain = { path = "../zebra/zebra-chain", default-features = false }
+zebra-consensus = { path = "../zebra/zebra-consensus", default-features = false }
+zebra-state = { path = "../zebra/zebra-state", default-features = false }
+zebra-test = { path = "../zebra/zebra-test", default-features = false }
+zebra-chain = { path = "../zebra/zebra-chain", default-features = false }
+zebra-script = { path = "../zebra/zebra-script", default-features = false }
 
 
 [patch.crates-io]

--- a/justfile
+++ b/justfile
@@ -9,9 +9,6 @@ run:
 run-local:
     ROLLUP_HTTP_SERVER_URL=http://127.0.0.1:8080/host-runner GRPC_SERVER_URL="[::1]:50051" cargo run
 
-run-proxy:
-    CARTESI_NODE_URL="0.0.0.0:8080" cargo run -p cartezcash-proxy
-
 sunodo-nobackend:
     sunodo run --no-backend
 

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ run:
     sunodo run --epoch-duration=10
 
 run-local:
-    ROLLUP_HTTP_SERVER_URL=http://127.0.0.1:8080/host-runner GRPC_SERVER_URL="[::1]:50051" cargo run
+    ROLLUP_HTTP_SERVER_URL=http://127.0.0.1:8080/host-runner GRPC_SERVER_URL="[::1]:50051" cargo run --features lightwalletd
 
 sunodo-nobackend:
     sunodo run --no-backend

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ use futures_util::future::FutureExt;
 
 use zebra_chain::{block, parameters::Network};
 
-
 #[cfg(feature = "lightwalletd")]
 use cartezcash_lightwalletd::{
     proto::service::compact_tx_streamer_server::CompactTxStreamerServer,
@@ -148,11 +147,8 @@ impl Service<RollAppRequest> for CarteZcashApp {
 
 async fn initialize_network<S>(tinycash: &mut S) -> Result<(), BoxError>
 where
-    S: Service<
-            tiny_cash::write::Request,
-            Response = tiny_cash::write::Response,
-            Error = BoxError,
-        > + Send
+    S: Service<tiny_cash::write::Request, Response = tiny_cash::write::Response, Error = BoxError>
+        + Send
         + Clone
         + 'static,
     S::Future: Send + 'static,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use tower_cartesi::{listen_http, Request as RollAppRequest, Response};
 use futures_util::future::FutureExt;
 
 use zebra_chain::{block, parameters::Network};
-use zebra_consensus::transaction as tx;
+
 
 #[cfg(feature = "lightwalletd")]
 use cartezcash_lightwalletd::{
@@ -56,7 +56,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // tiny_cash::initialize_halo2();
     // tracing::info!("Initializing Halo2 verifier key complete");
 
-    let (state_service, state_read_service, _, _) = zebra_state::init(
+    let (state_service, _state_read_service, _, _) = zebra_state::init(
         zebra_state::Config::ephemeral(),
         network,
         block::Height::MAX,

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // tiny_cash::initialize_halo2();
     // tracing::info!("Initializing Halo2 verifier key complete");
 
-    let (state_service, _state_read_service, _, _) = zebra_state::init(
+    let (state_service, state_read_service, _, _) = zebra_state::init(
         zebra_state::Config::ephemeral(),
         network,
         block::Height::MAX,
@@ -151,7 +151,7 @@ where
     S: Service<
             tiny_cash::write::Request,
             Response = tiny_cash::write::Response,
-            Error = tiny_cash::write::BoxError,
+            Error = BoxError,
         > + Send
         + Clone
         + 'static,

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), anyhow::Error> {
     );
     let state_service = Buffer::new(state_service, 30);
 
-    let mut cartezcash_app = CarteZcashApp::new(network, state_service).await;
+    let mut cartezcash_app = CarteZcashApp::new(state_service).await;
 
     #[cfg(feature = "lightwalletd")]
     {
@@ -93,13 +93,11 @@ struct CarteZcashApp {
 }
 
 impl CarteZcashApp {
-    pub async fn new(network: Network, state_service: StateService) -> Self {
+    pub async fn new(state_service: StateService) -> Self {
         // set up the services needed to run the rollup
-        let verifier_service = tx::Verifier::new(network, state_service.clone());
         let mut tinycash = Buffer::new(
             BoxService::new(tiny_cash::write::TinyCashWriteService::new(
                 state_service,
-                verifier_service,
             )),
             10,
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,9 +96,7 @@ impl CarteZcashApp {
     pub async fn new(state_service: StateService) -> Self {
         // set up the services needed to run the rollup
         let mut tinycash = Buffer::new(
-            BoxService::new(tiny_cash::write::TinyCashWriteService::new(
-                state_service,
-            )),
+            BoxService::new(tiny_cash::write::TinyCashWriteService::new(state_service)),
             10,
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,3 @@
-use cartezcash_lightwalletd::{
-    proto::service::compact_tx_streamer_server::CompactTxStreamerServer,
-    service_impl::CompactTxStreamerImpl,
-};
 use service::{CarteZcashService, Request};
 use zcash_keys::address::UnifiedAddress;
 use zcash_primitives::consensus::MAIN_NETWORK;
@@ -18,6 +14,12 @@ use futures_util::future::FutureExt;
 
 use zebra_chain::{block, parameters::Network};
 use zebra_consensus::transaction as tx;
+
+#[cfg(feature = "lightwalletd")]
+use cartezcash_lightwalletd::{
+    proto::service::compact_tx_streamer_server::CompactTxStreamerServer,
+    service_impl::CompactTxStreamerImpl,
+};
 
 type StateService = Buffer<
     BoxService<zebra_state::Request, zebra_state::Response, zebra_state::BoxError>,
@@ -39,7 +41,6 @@ async fn main() -> Result<(), anyhow::Error> {
     tracing::subscriber::set_global_default(subscriber)?;
 
     let server_addr = env::var("ROLLUP_HTTP_SERVER_URL")?;
-    let grpc_addr = env::var("GRPC_SERVER_URL")?;
 
     let network = Network::Mainnet;
 
@@ -62,18 +63,22 @@ async fn main() -> Result<(), anyhow::Error> {
         0,
     );
     let state_service = Buffer::new(state_service, 30);
-    let state_read_service = Buffer::new(state_read_service.boxed(), 30);
 
     let mut cartezcash_app = CarteZcashApp::new(network, state_service).await;
 
-    let svc = CompactTxStreamerServer::new(CompactTxStreamerImpl { state_read_service });
-    let addr = grpc_addr.parse()?;
-    let grpc_server = tonic::transport::Server::builder()
-        .trace_fn(|_| tracing::info_span!("cartezcash-grpc"))
-        .add_service(svc)
-        .serve(addr);
-    tokio::spawn(grpc_server);
-    tracing::info!("wallet GRPC server listening on {}", addr);
+    #[cfg(feature = "lightwalletd")]
+    {
+        let grpc_addr = env::var("GRPC_SERVER_URL")?;
+        let state_read_service = Buffer::new(state_read_service.boxed(), 30);
+        let svc = CompactTxStreamerServer::new(CompactTxStreamerImpl { state_read_service });
+        let addr = grpc_addr.parse()?;
+        let grpc_server = tonic::transport::Server::builder()
+            .trace_fn(|_| tracing::info_span!("cartezcash-grpc"))
+            .add_service(svc)
+            .serve(addr);
+        tokio::spawn(grpc_server);
+        tracing::info!("wallet GRPC server listening on {}", addr);
+    }
 
     listen_http(&mut cartezcash_app, &server_addr)
         .await

--- a/tiny-cash/Cargo.toml
+++ b/tiny-cash/Cargo.toml
@@ -16,6 +16,8 @@ zebra-consensus = { workspace = true, default-features = false, features = [] }
 zebra-state = { workspace = true, default-features = false, features = ["proptest-impl"] }
 zebra-test = { workspace = true, default-features = false }
 zebra-chain = { workspace = true, default-features = false, features = ["proptest-impl"] }
+zebra-script = { workspace = true }
+
 lazy_static = "1.4.0"
 orchard = "0.8.0"
 zcash_note_encryption = "0.4.0"

--- a/tiny-cash/Cargo.toml
+++ b/tiny-cash/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = "1.4.0"
 orchard = "0.8.0"
 zcash_note_encryption = "0.4.0"
 base58check = "0.1.0"
+incrementalmerkletree = "0.5.1"
 
 
 [dev-dependencies]

--- a/tiny-cash/src/test.rs
+++ b/tiny-cash/src/test.rs
@@ -16,7 +16,6 @@ use zebra_chain::{
     block,
     block::Height,
 };
-use zebra_consensus::transaction as tx;
 
 // anything sent to this script can be spent by anyway. Useful for testing
 fn accepting() -> Script {
@@ -35,9 +34,8 @@ async fn test_genesis() {
         0,
     );
     let state_service = Buffer::new(state_service, 1);
-    let verifier_service = tx::Verifier::new(network, state_service.clone());
 
-    let mut tinycash = BoxService::new(TinyCashWriteService::new(state_service, verifier_service));
+    let mut tinycash = BoxService::new(TinyCashWriteService::new(state_service));
 
     tinycash
         .call(Request::Genesis)
@@ -57,9 +55,8 @@ async fn test_mint_txns_update_balance() {
         0,
     );
     let state_service = Buffer::new(state_service, 10);
-    let verifier_service = tx::Verifier::new(network, state_service.clone());
 
-    let mut tinycash = BoxService::new(TinyCashWriteService::new(state_service, verifier_service));
+    let mut tinycash = BoxService::new(TinyCashWriteService::new(state_service));
 
     tinycash
         .ready()
@@ -134,9 +131,8 @@ async fn test_include_transparent_transaction() {
     );
 
     let state_service = Buffer::new(state_service, 10);
-    let verifier_service = tx::Verifier::new(network, state_service.clone());
 
-    let mut tinycash = BoxService::new(TinyCashWriteService::new(state_service, verifier_service));
+    let mut tinycash = BoxService::new(TinyCashWriteService::new(state_service));
 
     tinycash
         .ready()

--- a/tiny-cash/src/write.rs
+++ b/tiny-cash/src/write.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use futures_util::future::FutureExt;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -9,17 +9,17 @@ use std::{
 };
 use tower::{Service, ServiceExt};
 
+use zebra_chain::transparent;
 use zebra_chain::{
     amount::{Amount, NonNegative},
     block::{Block, Header, Height},
     fmt::HexDebug,
     parameters::{Network, NetworkUpgrade},
     transaction::HashType,
-    transparent::{OrderedUtxo, OutPoint, Utxo},
+    transparent::{OrderedUtxo, OutPoint},
     work::{difficulty::CompactDifficulty, equihash::Solution},
 };
 use zebra_chain::{block, serialization::ZcashDeserialize};
-use zebra_chain::{transaction::UnminedTxId, transparent};
 use zebra_chain::{
     transaction::{Memo, Transaction},
     transparent::Script,

--- a/tower-cartesi/examples/echo.rs
+++ b/tower-cartesi/examples/echo.rs
@@ -1,9 +1,9 @@
+use futures_util::FutureExt;
 use std::env;
 use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use futures_util::FutureExt;
 
 use tower_cartesi::{listen_http, Request, Response};
 use tower_service::{BoxError, Service};


### PR DESCRIPTION
Part of making the state transition constant sized means moving away from using the Zebra rocksdb as the main source of state. This worked well for the hackathon as it needed minimal protocol changes but for a proper rollup state transition we don't want to use Rocksdb.

This PR moves the minimal required state into the TinyCash struct. Turns out the state needed can actually be very small since there are no re-orgs or forks to worry about.

Closes #12 